### PR TITLE
upgrade default proguard version to 6.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: scala
+dist: xenial
 jdk: oraclejdk8
 script: sbt "^ scripted"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: scala
-dist: xenial
 jdk: oraclejdk8
 script: sbt "^ scripted"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: scala
+dist: trusty
 jdk: oraclejdk8
 script: sbt "^ scripted"

--- a/src/main/scala/com/typesafe/sbt/SbtProguard.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtProguard.scala
@@ -23,7 +23,7 @@ object SbtProguard extends AutoPlugin {
   override lazy val projectSettings: Seq[Setting[_]] = inConfig(Proguard)(baseSettings) ++ dependencies
 
   def baseSettings: Seq[Setting[_]] = Seq(
-    proguardVersion := "5.3.3",
+    proguardVersion := "6.2.2",
     proguardDirectory := crossTarget.value / "proguard",
     proguardConfiguration := proguardDirectory.value / "configuration.pro",
     artifactPath := proguardDirectory.value / (artifactPath in packageBin in Compile).value.getName,


### PR DESCRIPTION
Which isn't three years old and also supports java >= 9
Doesn't seem to cause any issues in our builds.