### PR TITLE
Choose the correct groupId for proguard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: scala
+dist: trusty
 jdk: oraclejdk8
 script: sbt "^ scripted"

--- a/src/main/scala/com/typesafe/sbt/SbtProguard.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtProguard.scala
@@ -55,8 +55,16 @@ object SbtProguard extends AutoPlugin {
     autoImport.proguard := proguardTask.value
   )
 
+  private def groupId(proguardVersionStr: String): String =
+    "^(\\d+)\\.".r
+      .findFirstMatchIn(proguardVersionStr)
+      .map(_.group(1).toInt) match {
+      case Some(v) => if (v > 6) "com.guardsquare" else "net.sf.proguard"
+      case None => sys.error(s"Can't parse Proguard version: $proguardVersion")
+    }
+
   def dependencies: Seq[Setting[_]] = Seq(
-    libraryDependencies += "net.sf.proguard" % "proguard-base" % (proguardVersion in Proguard).value % Proguard
+    libraryDependencies += groupId((proguardVersion in Proguard).value) % "proguard-base" % (proguardVersion in Proguard).value % Proguard
   )
 
   lazy val mergeTask: Def.Initialize[Task[Seq[ProguardOptions.Filtered]]] = Def.task {


### PR DESCRIPTION
GroupId for Proguard 7.0.0 has been updated to `com.guardsquare`
https://bintray.com/guardsquare/proguard/com.guardsquare%3Aproguard-base/7.0.0